### PR TITLE
Redirect to Post-Survey Timer Window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15447,6 +15447,14 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-countdown-circle-timer": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/react-countdown-circle-timer/-/react-countdown-circle-timer-2.5.3.tgz",
+      "integrity": "sha512-7uIopuZtR+nTWpfTpSD7aw2Ml8OxsTjI6nG5txuClUUxxnRphEkoDSo5qz8r7OYxgme7FpUHsDqueznYN3yLtg==",
+      "requires": {
+        "use-elapsed-time": "2.1.8"
+      }
+    },
     "react-dev-utils": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-4.2.3.tgz",
@@ -19417,6 +19425,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "use-elapsed-time": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/use-elapsed-time/-/use-elapsed-time-2.1.8.tgz",
+      "integrity": "sha512-lNLTDffKHdHWweQNvnch9tFI2eRP3tXccSLrwE7U6xrfyWFNEgNQZWWsGhQvtwKa0kJ6L+7E5wKbi3jg86opjg=="
     },
     "utif": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "prop-types": "^15.7.2",
     "query-string": "^6.13.1",
     "react": "^16.12.0",
+    "react-countdown-circle-timer": "^2.5.3",
     "react-dom": "^16.12.0",
     "react-helmet": "^6.1.0",
     "react-print-components": "^1.0.4",

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -6,6 +6,7 @@ import Img from "gatsby-image"
 import InfoIcon from "../icons/info"
 import PrivacyTipIcon from "../icons/privacy_tip"
 import PrivacyDialog from "./privacy_dialog"
+import TimerDialog from "./timer_dialog"
 import InfoDialog from "./info_dialog"
 import BorderColorIcon from '@material-ui/icons/BorderColor';
 import "./header.scss"
@@ -24,10 +25,31 @@ const Header = ({ siteTitle }) => {
   `)
 
   const [windowWidth, setWindowWidth] = useState(null)
+  const [seconds, setSeconds] = React.useState(10);
 
   const updateWindowSize = () => {
     setWindowWidth(window.innerWidth)
   }
+
+  
+
+  const open = (url) => {
+  const win = window.open(url, '_blank');
+  if (win != null) {
+    win.focus();
+  }
+}
+
+  useEffect(() => {
+    if (seconds > 5) {
+      setTimeout(() => setSeconds(seconds - 1), 1000);
+    } else {
+      if(seconds!=0) {
+        setSeconds(0);
+        setOpenTimer(true);
+      }   
+    }
+  });
 
   useEffect(() => {
     window.addEventListener("resize", updateWindowSize)
@@ -35,6 +57,7 @@ const Header = ({ siteTitle }) => {
   }, [])
 
   const [openPrivacy, setOpenPrivacy] = useState(false)
+  const [openTimer, setOpenTimer] = useState(false)
   const [selectedPrivacyValue, setSelectedPrivacyValue] = useState(null)
 
   const [openInfo, setOpenInfo] = useState(false)
@@ -50,6 +73,11 @@ const Header = ({ siteTitle }) => {
   const handleClosePrivacy = (value: string) => {
     setOpenPrivacy(false)
     setSelectedPrivacyValue(value)
+  }
+
+  const handleCloseTimer = () => {
+    setOpenTimer(false);
+    open("https://www.google.com/");
   }
 
   const handleClickOpenInfo = () => {
@@ -114,6 +142,10 @@ const Header = ({ siteTitle }) => {
         open={openPrivacy}
         onClose={handleClosePrivacy}
       /> 
+      <TimerDialog
+      open={openTimer}
+      onClose={handleCloseTimer}
+      ></TimerDialog>
       <InfoDialog
         selectedValue={selectedInfoValue}
         open={openInfo}

--- a/src/components/timer_dialog.tsx
+++ b/src/components/timer_dialog.tsx
@@ -1,0 +1,48 @@
+import React, { Suspense } from "react"
+import Dialog from "@material-ui/core/Dialog"
+import DialogContent from "@material-ui/core/DialogContent"
+import DialogTitle from "@material-ui/core/DialogTitle"
+import { CountdownCircleTimer } from 'react-countdown-circle-timer'
+
+export interface SimpleDialogProps {
+  open: boolean
+  onClose: () => void
+}
+
+
+const TimerDialog = (props: SimpleDialogProps) => {
+  const { onClose, open } = props;
+  return (
+    <Dialog
+    open={open}
+    onClose={(event, reason) => {
+           if (reason !== 'backdropClick') {
+             onClose();
+          }
+          }}
+     aria-labelledby="alert-dialog-title"
+     aria-describedby="alert-dialog-description"
+    >
+      <DialogTitle id="alert-dialog-title">Going to pre survey link</DialogTitle>
+      <DialogContent>
+      <p style={{textAlign:'center'}}>Redirecting in</p>
+      <CountdownCircleTimer
+    isPlaying
+    onComplete={() => {
+      onClose();
+    }}
+    duration={5}
+    ariaLabel="Redirecting in..."
+    colors={[
+      ['#004777', 0.33],
+      ['#F7B801', 0.33],
+      ['#A30000', 0.33],
+    ]}
+  >
+    {({ remainingTime }) => remainingTime}
+  </CountdownCircleTimer>
+      </DialogContent>
+    </Dialog>
+  );
+}
+export default TimerDialog


### PR DESCRIPTION
A window pops up to countdown from 5 seconds until redirecting users to the post-survey link (new tab). As of now, I sent the timer window to trigger after 10 seconds upon loading the page. This can be changed in header.tsx on line 28. 